### PR TITLE
chore(samples): pin to 2.0.7-rc2 (OS-16071)

### DIFF
--- a/BackgroundSampleApp.xcodeproj/project.pbxproj
+++ b/BackgroundSampleApp.xcodeproj/project.pbxproj
@@ -392,8 +392,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/OneStepRND/onestep-sdk-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = "2.0.7-rc2";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OneStepSDKSampleApp.xcodeproj/project.pbxproj
+++ b/OneStepSDKSampleApp.xcodeproj/project.pbxproj
@@ -406,8 +406,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/OneStepRND/onestep-sdk-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = "2.0.7-rc2";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OneStepSDKSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneStepSDKSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneStepRND/onestep-sdk-ios",
       "state" : {
-        "revision" : "1c991ac0dca9f579df5cdc57abb13e61886d63fb",
-        "version" : "2.0.3"
+        "revision" : "43c14c53ff0b4e0b8c0714bf5fbd0d36709bccad",
+        "version" : "2.0.7-rc2"
       }
     }
   ],

--- a/OneStepSamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OneStepSamples.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneStepRND/onestep-sdk-ios",
       "state" : {
-        "revision" : "1c991ac0dca9f579df5cdc57abb13e61886d63fb",
-        "version" : "2.0.3"
+        "revision" : "43c14c53ff0b4e0b8c0714bf5fbd0d36709bccad",
+        "version" : "2.0.7-rc2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/OneStepRND/onestep-uikit-ios-spm",
       "state" : {
-        "revision" : "e574d8716ace85d6b645ea28a3fad658d7de2c1a",
-        "version" : "2.0.3"
+        "revision" : "c279ee724c3a12d06c931818e90a11b6b08c2a84",
+        "version" : "2.0.7-rc2"
       }
     },
     {

--- a/OneStepUIKitExample.xcodeproj/project.pbxproj
+++ b/OneStepUIKitExample.xcodeproj/project.pbxproj
@@ -388,8 +388,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/OneStepRND/onestep-uikit-ios-spm";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = "2.0.7-rc2";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Pins the sample apps (OneStepSDKSampleApp, BackgroundSampleApp, OneStepUIKitExample) to an exact **2.0.7-rc2** of onestep-sdk-ios / onestep-uikit-ios-spm so they build against the rc. Range requirements don't match pre-release tags, hence the switch to exactVersion.